### PR TITLE
Increase worker timeout

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
         "nixpacksVersion": "1.34.0"
     },
     "deploy": {
-        "startCommand": "gunicorn 'app.factory:create_app()' -w 2 --bind 0.0.0.0:80 --access-logfile '-'",
+        "startCommand": "gunicorn 'app.factory:create_app()' -t 300 -w 2 --bind 0.0.0.0:80 --access-logfile '-'",
         "restartPolicyType": "ON_FAILURE",
         "restartPolicyMaxRetries": 3
     }


### PR DESCRIPTION
Some endpoints may take longer time to execute, let's set timeout to 300s.